### PR TITLE
Add section about building the executable to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@ Running compute-intense parts of BigStitcher distributed. For now we support **f
 
 Sharing this early as it might be useful ...
 
+## Install
+
+* Prerequisites:  Java and maven must be installed.
+* Clone the repo and `cd` into `BigStitcher-Spark`
+* Run the included bash script `./install -t <num-cores> -m <mem-in-GB> ` specifying the number of cores and available memory in GB for running locally. This should build the project and create an executable `affine-fusion` in the working directory.
+
+## Usage
+
 Here is my example config for this [example dataset](https://drive.google.com/file/d/1SXossOV3gOdIWI4RcDn-YjUYS9SMh5mm/view?usp=sharing) for the main class `net.preibisch.bigstitcher.spark.AffineFusion`:
 
 ```


### PR DESCRIPTION
This adds a short section pointing out the `install` script and its options.

Background:
When trying to install this on my local machine, I had various issues trying to build/install this as a non-Java-person. 
I managed to build with maven eventually but had problems with dependencies. Only then did I notice the `install` script that handled all of this gracefully. I think it deserves a prominent placement in the README :)