### PR TITLE
Upgrade bdv and imglib dependencies while keeping scijava and spark version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,10 +164,6 @@
             <version>2.4.7</version>
             <exclusions>
                 <exclusion>
-                    <artifactId>netty-all</artifactId>
-                    <groupId>io.netty</groupId>
-                </exclusion>
-                <exclusion>
                     <artifactId>jcl-over-slf4j</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
+<!--            Spark 2.4.7 release comes with scala 2.11.12 -->
+            <artifactId>spark-core_2.11</artifactId>
             <version>2.4.7</version>
             <exclusions>
                 <exclusion>
@@ -205,7 +206,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.12.18</version>
+            <version>2.11.12</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,12 +46,12 @@
         </developer>
     </developers>
 
-	<contributors>
-       <contributor>
+    <contributors>
+        <contributor>
             <name>Marwan Zouinkhi</name>
             <url>https://</url>
         </contributor>
-	</contributors>
+    </contributors>
 
     <mailingLists>
         <mailingList>
@@ -60,20 +60,20 @@
         </mailingList>
     </mailingLists>
 
-	<scm>
-		<connection>scm:git:https://github.com/PreibischLab/BigStitcher-Spark</connection>
-		<developerConnection>scm:git:git@github.com:PreibischLab/BigStitcher-Spark</developerConnection>
-		<tag>HEAD</tag>
-		<url>https://github.com/PreibischLab/BigStitcher-Spark</url>
-	</scm>
-	<issueManagement>
-		<system>GitHub Issues</system>
-		<url>https://github.com/PreibischLab/BigStitcher-Spark/issues</url>
-	</issueManagement>
-	<ciManagement>
-		<system>GitHub Actions</system>
-		<url>https://github.com/PreibischLab/BigStitcher-Spark/actions</url>
-	</ciManagement>
+    <scm>
+        <connection>scm:git:https://github.com/PreibischLab/BigStitcher-Spark</connection>
+        <developerConnection>scm:git:git@github.com:PreibischLab/BigStitcher-Spark</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/PreibischLab/BigStitcher-Spark</url>
+    </scm>
+    <issueManagement>
+        <system>GitHub Issues</system>
+        <url>https://github.com/PreibischLab/BigStitcher-Spark/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>GitHub Actions</system>
+        <url>https://github.com/PreibischLab/BigStitcher-Spark/actions</url>
+    </ciManagement>
 
     <properties>
         <!-- <scijava.jvm.version>1.8</scijava.jvm.version> -->
@@ -97,7 +97,22 @@
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>bigdataviewer-core</artifactId>
-            <version>10.3.0</version>
+            <version>10.4.6</version>
+        </dependency>
+        <dependency>
+            <groupId>sc.fiji</groupId>
+            <artifactId>bigdataviewer-vistools</artifactId>
+            <version>1.0.0-beta-32</version>
+        </dependency>
+        <dependency>
+            <groupId>net.imglib2</groupId>
+            <artifactId>imglib2-cache</artifactId>
+            <version>1.0.0-beta-17</version>
+        </dependency>
+        <dependency>
+            <groupId>net.imglib2</groupId>
+            <artifactId>imglib2</artifactId>
+            <version>6.1.0</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
@@ -111,11 +126,17 @@
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5</artifactId>
-            <version>2.2.1</version>
+            <version>2.5.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bigdataviewer</groupId>
+            <artifactId>bigdataviewer-omezarr</artifactId>
+            <version>0.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-zarr</artifactId>
+            <version>0.0.8</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
@@ -139,14 +160,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_2.12</artifactId>
             <version>2.4.7</version>
             <exclusions>
                 <exclusion>
                     <artifactId>netty-all</artifactId>
                     <groupId>io.netty</groupId>
                 </exclusion>
-
                 <exclusion>
                     <artifactId>jcl-over-slf4j</artifactId>
                     <groupId>org.slf4j</groupId>
@@ -172,6 +192,10 @@
                     <groupId>org.glassfish.jersey.core</groupId>
                 </exclusion>
                 <exclusion>
+                    <artifactId>jersey-core</artifactId>
+                    <groupId>com.sun.jersey</groupId>
+                </exclusion>
+                <exclusion>
                     <artifactId>lz4</artifactId>
                     <groupId>net.jpountz.lz4</groupId>
                 </exclusion>
@@ -183,107 +207,125 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.12.18</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>4.1.17.Final</version>
+            <groupId>net.preibisch</groupId>
+            <artifactId>multiview-reconstruction</artifactId>
+            <version>2.0.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.epfl.biop</groupId>
+                    <artifactId>ijp-kheops</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-            <version>3.9.9.Final</version>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
         </dependency>
-		<dependency>
-			<groupId>net.preibisch</groupId>
-			<artifactId>multiview-reconstruction</artifactId>
-			<version>1.0.1</version>
-		</dependency>
-		<dependency>
-			<groupId>info.picocli</groupId>
-			<artifactId>picocli</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.janelia.saalfeldlab</groupId>
-			<artifactId>n5-hdf5</artifactId>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/net.java.dev.jna/jna needed for M1 native library loading -->
-		<dependency>
-			<groupId>net.java.dev.jna</groupId>
-			<artifactId>jna</artifactId>
-			<version>5.7.0</version>
-		</dependency>
-	</dependencies>
-	<groupId>net.preibisch</groupId>
+        <dependency>
+            <groupId>org.janelia.saalfeldlab</groupId>
+            <artifactId>n5-hdf5</artifactId>
+            <version>1.4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janelia.saalfeldlab</groupId>
+            <artifactId>n5-imglib2</artifactId>
+            <version>5.0.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/net.java.dev.jna/jna needed for M1 native library loading -->
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.7.0</version>
+        </dependency>
+    </dependencies>
+    <groupId>net.preibisch</groupId>
 
-	<profiles>
-	<profile>
-			<id>fatjar</id>
-			<build>
-				<plugins>
-					<!-- Maven shade for Uber Jar -->
-					<!-- https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html -->
-					<!-- https://databricks.gitbooks.io/databricks-spark-knowledge-base/content/troubleshooting/missing_dependencies_in_jar_files.html -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-shade-plugin</artifactId>
-						<configuration>
-							<!-- Do not minimize for now to speed up packaging. -->
-							<transformers combine.children="append">
-								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-									<resource>META-INF/json/mpicbg.spim.data.generic.sequence.ImgLoaderIo</resource>
-								</transformer>
-							</transformers>
-							<!--<minimizeJar>true</minimizeJar> -->
-							<filters>
-								<filter>
-									<artifact>*:*</artifact>
-									<excludes>
+    <profiles>
+        <profile>
+            <id>fatjar</id>
+            <build>
+                <plugins>
+                    <!-- Maven shade for Uber Jar -->
+                    <!-- https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html -->
+                    <!-- https://databricks.gitbooks.io/databricks-spark-knowledge-base/content/troubleshooting/missing_dependencies_in_jar_files.html -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <configuration>
+                            <!-- Do not minimize for now to speed up packaging. -->
+                            <transformers combine.children="append">
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/json/mpicbg.spim.data.generic.sequence.ImgLoaderIo</resource>
+                                </transformer>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>META-INF/json/org.janelia.saalfeldlab.n5.Compression$CompressionType</resource>
+                                </transformer>
+                            </transformers>
+                            <!--<minimizeJar>true</minimizeJar> -->
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
                                         <exclude>Angle0.tif</exclude>
                                         <exclude>LICENSE</exclude>
+                                        <exclude>LICENSE.txt</exclude>
                                         <exclude>META-INF/DEPENDENCIES</exclude>
                                         <exclude>META-INF/LICENSE</exclude>
                                         <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/BSDL</exclude>
+                                        <exclude>META-INF/COPYING</exclude>
+                                        <exclude>META-INF/LEGAL</exclude>
+                                        <exclude>META-INF/LICENSE.RUBY</exclude>
                                         <exclude>META-INF/json/org.scijava.plugin.Plugin</exclude>
                                         <exclude>META-INF/*.MF</exclude>
-										<exclude>META-INF/*.SF</exclude>
-										<exclude>META-INF/*.DSA</exclude>
-										<exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
                                         <exclude>META-INF/*.txt</exclude>
                                         <exclude>module-info.class</exclude>
                                         <exclude>plugins.config</exclude>
-									</excludes>
-								</filter>
-							</filters>
-							<!-- Additional configuration. -->
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- Additional configuration. -->
                             <artifactSet>
                                 <excludes>
                                     <exclude>*jackson*</exclude>
+<!--                                    <exclude>com.github.jnr:jnr-ffi</exclude>-->
                                 </excludes>
                             </artifactSet>
                             <relocations>
-								<relocation>
-									<pattern>org.apache.commons.compress</pattern>
-									<shadedPattern>org.janelia.saalfeldlab.org.apache.commons.compress</shadedPattern>
-								</relocation>
-							</relocations>
-						</configuration>
-						<!-- binds by default to package phase -->
-						<executions>
-							<execution>
-								<phase>package</phase>
-								<goals>
-									<goal>shade</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<!-- Maven shade end -->
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+                                <relocation>
+                                    <pattern>org.apache.commons.compress</pattern>
+                                    <shadedPattern>org.janelia.saalfeldlab.org.apache.commons.compress</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                        <!-- binds by default to package phase -->
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Maven shade end -->
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/net/preibisch/bigstitcher/spark/AffineFusion.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/AffineFusion.java
@@ -366,12 +366,11 @@ public class AffineFusion implements Callable<Void>, Serializable
 					// nothing to save...
 					if ( viewIdsLocal.size() == 0 )
 						return;
-
 					final RandomAccessibleInterval<FloatType> source = FusionTools.fuseVirtual(
 								dataLocal,
 								viewIdsLocal,
-								new FinalInterval(minBB, maxBB),
-								Double.NaN ).getA();
+								new FinalInterval(minBB, maxBB)
+					);
 
 					final N5Writer executorVolumeWriter;
 

--- a/src/main/java/net/preibisch/bigstitcher/spark/NonRigidFusionSpark.java
+++ b/src/main/java/net/preibisch/bigstitcher/spark/NonRigidFusionSpark.java
@@ -380,9 +380,8 @@ public class NonRigidFusionSpark implements Callable<Void>, Serializable
 									virtualGrid,
 									interpolation,
 									fusedBlock,
-									downsampling,
 									null,
-									service ).getA();
+									service );
 
 					service.shutdown();
 


### PR DESCRIPTION
 * New version of bigdataviewer-vistools, imglib2-cache for wrapAsVolatile and CachedCellImage signature updates.
 * Added imbglib2, n5-imglib2, n5-zarr versions so that pom-scijava can be left unchanged.
 * For unknown reasons, pulled in spark dependencies changed and scala-lang 2.11.12 must be added explicitly, otherwise omitted.
 * Update fusion method signatures in AffineFusion changed after multiview-reconstruction 1.0.1 -> downsampling removed for fusion methods.
 * Added released bigdataviewer-omezarr as zarr dependency.
 * Fix duplicate classes.
 * Fix n5 compression annotation jsons.
 * pom reformatting
 * Excluding ijp-kheops bioformats from multiview-reconstruction. Source of most conflict. BS-S does not need it.