### PR TITLE
Upgrade to Spark-3.3.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,9 +76,6 @@
     </ciManagement>
 
     <properties>
-        <!-- <scijava.jvm.version>1.8</scijava.jvm.version> -->
-<!--        <bigdataviewer-core.version>10.3.0</bigdataviewer-core.version>-->
-<!--        <spim_data.version>2.2.7</spim_data.version>-->
         <license.licenseName>gpl_v2</license.licenseName>
         <license.copyrightOwners>Developers.</license.copyrightOwners>
     </properties>
@@ -99,11 +96,6 @@
             <artifactId>bigdataviewer-core</artifactId>
             <version>10.4.6</version>
         </dependency>
-        <!-- <dependency> -->
-        <!--     <groupId>io.netty</groupId> -->
-        <!--     <artifactId>netty-all</artifactId> -->
-        <!--     <version>4.1.47.Final</version> -->
-        <!-- </dependency> -->
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>bigdataviewer-vistools</artifactId>
@@ -146,17 +138,7 @@
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-aws-s3</artifactId>
             <version>4.0.0</version>
-<!--            <exclusions>-->
-<!--                <exclusion>-->
-<!--                    <groupId>org.janelia.saalfeldlab</groupId>-->
-<!--                    <artifactId>n5</artifactId>-->
-<!--                </exclusion>-->
-<!--            </exclusions>-->
         </dependency>
-        <!-- <dependency> -->
-        <!--     <groupId>ch.qos.logback</groupId> -->
-        <!--     <artifactId>logback-classic</artifactId> -->
-        <!-- </dependency> -->
 <!--        Scala is sensitive to fasterxml version -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -173,38 +155,6 @@
                     <artifactId>jcl-over-slf4j</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
-<!--                <exclusion>-->
-<!--                    <artifactId>jul-to-slf4j</artifactId>-->
-<!--                    <groupId>org.slf4j</groupId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>slf4j-log4j12</artifactId>-->
-<!--                    <groupId>org.slf4j</groupId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>aopalliance-repackaged</artifactId>-->
-<!--                    <groupId>org.glassfish.hk2.external</groupId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>javax.inject</artifactId>-->
-<!--                    <groupId>org.glassfish.hk2.external</groupId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>jersey-client</artifactId>-->
-<!--                    <groupId>org.glassfish.jersey.core</groupId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>jersey-core</artifactId>-->
-<!--                    <groupId>com.sun.jersey</groupId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>lz4</artifactId>-->
-<!--                    <groupId>net.jpountz.lz4</groupId>-->
-<!--                </exclusion>-->
-<!--                <exclusion>-->
-<!--                    <artifactId>jets3t</artifactId>-->
-<!--                    <groupId>net.java.dev.jets3t</groupId>-->
-<!--                </exclusion>-->
             </exclusions>
             <scope>provided</scope>
         </dependency>
@@ -213,10 +163,6 @@
             <artifactId>scala-library</artifactId>
             <version>2.12.15</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.google.guava</groupId>-->
-<!--            <artifactId>guava</artifactId>-->
-<!--        </dependency>-->
         <dependency>
             <groupId>net.preibisch</groupId>
             <artifactId>multiview-reconstruction</artifactId>
@@ -228,17 +174,12 @@
                 </exclusion>
                 <exclusion>
                     <groupId>com.esotericsoftware</groupId>
-                    <!--                    <artifactId>kryo-shaded</artifactId>-->
                     <artifactId>reflectasm</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.esotericsoftware</groupId>
                     <artifactId>kryo</artifactId>
                 </exclusion>
-<!--                <exclusion>-->
-<!--                    <groupId>gov.nist.isg</groupId>-->
-<!--                    <artifactId>pyramidio</artifactId>-->
-<!--                </exclusion>-->
             </exclusions>
         </dependency>
         <dependency>
@@ -259,8 +200,6 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-<!--            <version>5.7.0</version>-->
-<!--            <version>5.13.0</version>-->
         </dependency>
     </dependencies>
     <groupId>net.preibisch</groupId>
@@ -320,9 +259,7 @@
                             <!-- Additional configuration. -->
                             <artifactSet>
                                 <excludes>
-<!--                                    <exclude>*jackson*</exclude>-->
-				    <!--                                    <exclude>com.github.jnr:jnr-ffi</exclude>-->
-				    <exclude>xpp3:xpp3</exclude>
+				                    <exclude>xpp3:xpp3</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>
@@ -352,5 +289,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
 
     <properties>
         <!-- <scijava.jvm.version>1.8</scijava.jvm.version> -->
-        <bigdataviewer-core.version>10.3.0</bigdataviewer-core.version>
-        <spim_data.version>2.2.7</spim_data.version>
+<!--        <bigdataviewer-core.version>10.3.0</bigdataviewer-core.version>-->
+<!--        <spim_data.version>2.2.7</spim_data.version>-->
         <license.licenseName>gpl_v2</license.licenseName>
         <license.copyrightOwners>Developers.</license.copyrightOwners>
     </properties>
@@ -99,6 +99,11 @@
             <artifactId>bigdataviewer-core</artifactId>
             <version>10.4.6</version>
         </dependency>
+        <!-- <dependency> -->
+        <!--     <groupId>io.netty</groupId> -->
+        <!--     <artifactId>netty-all</artifactId> -->
+        <!--     <version>4.1.47.Final</version> -->
+        <!-- </dependency> -->
         <dependency>
             <groupId>sc.fiji</groupId>
             <artifactId>bigdataviewer-vistools</artifactId>
@@ -112,7 +117,7 @@
         <dependency>
             <groupId>net.imglib2</groupId>
             <artifactId>imglib2</artifactId>
-            <version>6.1.0</version>
+            <version>6.2.0</version>
         </dependency>
         <dependency>
             <groupId>sc.fiji</groupId>
@@ -121,97 +126,97 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>${aws-java-sdk-s3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.janelia.saalfeldlab</groupId>
-            <artifactId>n5</artifactId>
-            <version>2.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.bigdataviewer</groupId>
             <artifactId>bigdataviewer-omezarr</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2-keyvalue-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.janelia.saalfeldlab</groupId>
+            <artifactId>n5</artifactId>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-zarr</artifactId>
-            <version>0.0.8</version>
+            <version>1.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-aws-s3</artifactId>
-            <version>3.2.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.janelia.saalfeldlab</groupId>
-                    <artifactId>n5</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>4.0.0</version>
+<!--            <exclusions>-->
+<!--                <exclusion>-->
+<!--                    <groupId>org.janelia.saalfeldlab</groupId>-->
+<!--                    <artifactId>n5</artifactId>-->
+<!--                </exclusion>-->
+<!--            </exclusions>-->
         </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
+        <!-- <dependency> -->
+        <!--     <groupId>ch.qos.logback</groupId> -->
+        <!--     <artifactId>logback-classic</artifactId> -->
+        <!-- </dependency> -->
+<!--        Scala is sensitive to fasterxml version -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.5</version>
+            <version>2.13.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-<!--            Spark 2.4.7 release comes with scala 2.11.12 -->
-            <artifactId>spark-core_2.11</artifactId>
-            <version>2.4.7</version>
+<!--            Spark 3.3.2 release comes with scala 2.12.15 -->
+            <artifactId>spark-core_2.12</artifactId>
+            <version>3.3.2</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jcl-over-slf4j</artifactId>
                     <groupId>org.slf4j</groupId>
                 </exclusion>
-                <exclusion>
-                    <artifactId>jul-to-slf4j</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>slf4j-log4j12</artifactId>
-                    <groupId>org.slf4j</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>aopalliance-repackaged</artifactId>
-                    <groupId>org.glassfish.hk2.external</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>javax.inject</artifactId>
-                    <groupId>org.glassfish.hk2.external</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jersey-client</artifactId>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jersey-core</artifactId>
-                    <groupId>com.sun.jersey</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>lz4</artifactId>
-                    <groupId>net.jpountz.lz4</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>jets3t</artifactId>
-                    <groupId>net.java.dev.jets3t</groupId>
-                </exclusion>
+<!--                <exclusion>-->
+<!--                    <artifactId>jul-to-slf4j</artifactId>-->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <artifactId>slf4j-log4j12</artifactId>-->
+<!--                    <groupId>org.slf4j</groupId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <artifactId>aopalliance-repackaged</artifactId>-->
+<!--                    <groupId>org.glassfish.hk2.external</groupId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <artifactId>javax.inject</artifactId>-->
+<!--                    <groupId>org.glassfish.hk2.external</groupId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <artifactId>jersey-client</artifactId>-->
+<!--                    <groupId>org.glassfish.jersey.core</groupId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <artifactId>jersey-core</artifactId>-->
+<!--                    <groupId>com.sun.jersey</groupId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <artifactId>lz4</artifactId>-->
+<!--                    <groupId>net.jpountz.lz4</groupId>-->
+<!--                </exclusion>-->
+<!--                <exclusion>-->
+<!--                    <artifactId>jets3t</artifactId>-->
+<!--                    <groupId>net.java.dev.jets3t</groupId>-->
+<!--                </exclusion>-->
             </exclusions>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>2.11.12</version>
+            <version>2.12.15</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.google.guava</groupId>-->
+<!--            <artifactId>guava</artifactId>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>net.preibisch</groupId>
             <artifactId>multiview-reconstruction</artifactId>
@@ -222,9 +227,18 @@
                     <artifactId>ijp-kheops</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>gov.nist.isg</groupId>
-                    <artifactId>pyramidio</artifactId>
+                    <groupId>com.esotericsoftware</groupId>
+                    <!--                    <artifactId>kryo-shaded</artifactId>-->
+                    <artifactId>reflectasm</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.esotericsoftware</groupId>
+                    <artifactId>kryo</artifactId>
+                </exclusion>
+<!--                <exclusion>-->
+<!--                    <groupId>gov.nist.isg</groupId>-->
+<!--                    <artifactId>pyramidio</artifactId>-->
+<!--                </exclusion>-->
             </exclusions>
         </dependency>
         <dependency>
@@ -234,7 +248,7 @@
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
             <artifactId>n5-hdf5</artifactId>
-            <version>1.4.2</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.janelia.saalfeldlab</groupId>
@@ -245,7 +259,8 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>5.7.0</version>
+<!--            <version>5.7.0</version>-->
+<!--            <version>5.13.0</version>-->
         </dependency>
     </dependencies>
     <groupId>net.preibisch</groupId>
@@ -296,20 +311,29 @@
                                         <exclude>META-INF/*.txt</exclude>
                                         <exclude>module-info.class</exclude>
                                         <exclude>plugins.config</exclude>
+					                    <exclude>META-INF/versions/9/module-info.class</exclude>
+					                    <exclude>META-INF/okio.kotlin_module</exclude>
+                                        <exclude>META-INF/services/com.fasterxml.jackson.core.JsonFactory</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
                             <!-- Additional configuration. -->
                             <artifactSet>
                                 <excludes>
-                                    <exclude>*jackson*</exclude>
-<!--                                    <exclude>com.github.jnr:jnr-ffi</exclude>-->
+<!--                                    <exclude>*jackson*</exclude>-->
+				    <!--                                    <exclude>com.github.jnr:jnr-ffi</exclude>-->
+				    <exclude>xpp3:xpp3</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.commons.compress</pattern>
                                     <shadedPattern>org.janelia.saalfeldlab.org.apache.commons.compress</shadedPattern>
+                                </relocation>
+                                <!-- Protect newer gson version from the old one preloaded by spark -->
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>org.janelia.saalfeldlab.com.google.gson</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION

 * Manual merge of pom changes by @StephanPreibisch.
 * Upgrade pom to released n5 packages and removing unnecessary versions in the new scijava.
 * Fix duplicate classes in pom.
 * Remove unnecessary explicit versions, exclusions.
 * Additional pom cleanup.

 @StephanPreibisch I upgraded the dependencies to Spark-3.3.2 on top of your `mvr` and related upgrade. Tested with simple, fatjar build and direct `java` and `spark-submit` runs. 

@trautmane The fatjar creation complained about the duplication of the following meta files. As far as I understand the first two items come from the different java version kotlin modules which may not be the used at the same time. I'm unsure about the `jackson` one. Is it OK to simply exclude these from the fatjar ?

```xml
<exclude>META-INF/versions/9/module-info.class</exclude>
<exclude>META-INF/okio.kotlin_module</exclude>
<exclude>META-INF/services/com.fasterxml.jackson.core.JsonFactory</exclude>
```
